### PR TITLE
Add CODEOWNERS for infra-team and kohls-team [sc-117272]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mechanical-orchard/infra-team @mechanical-orchard/kohls-team


### PR DESCRIPTION
Adds a default CODEOWNERS file making infra-team and kohls-team owners of everything, for repo ownership conformity.

[sc-117272]

🤖 Generated with [Claude Code](https://claude.com/claude-code)