### PR TITLE
Normalize CODEOWNERS to workspace standard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mechanical-orchard/infra-team @mechanical-orchard/kohls-team
+* @mechanical-orchard/kohls-team @mechanical-orchard/infra-team


### PR DESCRIPTION
Align this repo's `.github/CODEOWNERS` with the koi-workspace standard so every managed repo shares the same code owners (`@mechanical-orchard/kohls-team @mechanical-orchard/infra-team`). Enforced by `bin/github-repo-conformity-checker.sh`.

sc-121298

🤖 Generated with [Claude Code](https://claude.com/claude-code)